### PR TITLE
Use Node built-in UUID method

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,7 +1,5 @@
-
 var crypto = require('crypto')
 var qs = require('qs')
-var uuid = require('uuid').v4
 var _oauth = require('oauth-sign')
 
 
@@ -78,7 +76,7 @@ function buildParams (oauth, uri, method, query, form) {
     oa.oauth_timestamp = Math.floor(Date.now() / 1000).toString()
   }
   if (!oa.oauth_nonce) {
-    oa.oauth_nonce = uuid().replace(/-/g, '')
+    oa.oauth_nonce = crypto.randomUUID().replace(/-/g, '')
   }
   if (!oa.oauth_signature_method) {
     oa.oauth_signature_method = 'HMAC-SHA1'

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/simov/request-oauth.git"
   },
   "dependencies": {
-    "qs": "^6.9.6",
-    "uuid": "^8.3.2",
-    "oauth-sign": "^0.9.0"
+    "oauth-sign": "^0.9.0",
+    "qs": "^6.9.6"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",
@@ -44,6 +43,6 @@
     "test:cov": "npx nyc --reporter=lcov --reporter=text-summary mocha -- --recursive"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=16.7.0"
   }
 }


### PR DESCRIPTION
closes https://github.com/simov/request-oauth/issues/3

had to bump the `engines` field for this. if you're open to accepting this and cutting a major, it might also be worth considering whether you'd want to convert to ESM and adopt `module-sync` with a further `engines` bump