### PR TITLE
Drop `qs` dependency in favor of `URLSearchParams`

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,6 +1,6 @@
 
 var crypto = require('crypto')
-var qs = require('qs')
+var URLSearchParams = require('url').URLSearchParams
 var uuid = require('uuid').v4
 var _oauth = require('oauth-sign')
 
@@ -97,7 +97,20 @@ function buildParams (oauth, uri, method, query, form) {
   delete oa.oauth_transport_method
 
   var baseurl = uri.protocol + '//' + uri.host + uri.pathname
-  var params = qs.parse([].concat(query, form, qs.stringify(oa)).join('&'))
+
+  const searchParams = new URLSearchParams([].concat(query, form, new URLSearchParams(oa).toString()).join('&'))
+  const params = {}
+  for (const [key, value] of searchParams.entries()) {
+    if (params.hasOwnProperty(key)) {
+      if (Array.isArray(params[key])) {
+        params[key].push(value)
+      } else {
+        params[key] = [params[key], value]
+      }
+    } else {
+      params[key] = value
+    }
+  }
 
   oa.oauth_signature = _oauth.sign(
     oa.oauth_signature_method,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/simov/request-oauth.git"
   },
   "dependencies": {
-    "qs": "^6.9.6",
     "uuid": "^8.3.2",
     "oauth-sign": "^0.9.0"
   },


### PR DESCRIPTION
This removes the need for `qs` as well as its 18 transitive dependencies